### PR TITLE
Support skipping Ruby install if cache is available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,19 @@ jobs:
         ruby-version: 2.6.5
     - name: Print version
       run: ${{ steps.ruby.outputs.ruby-path }} --version
+  test-cached:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/cache@preview
+      id: cache
+      with:
+        path: ~/local/rubies
+        key: ruby-2.6.5
+    - uses: ./
+      id: ruby
+      with:
+        ruby-version: 2.6.5
+        cache-available: ${{ steps.cache.outputs.cache-hit == 'true' }}
+    - name: Print version
+      run: ${{ steps.ruby.outputs.ruby-path }} --version

--- a/README.md
+++ b/README.md
@@ -8,17 +8,18 @@ Uses [ruby-build](https://github.com/rbenv/ruby-build) to install a Ruby version
 
 ### Pre-requisites
 
-Create a workflow `.yml` file in your repositories `.github/workflows` directory. An [example workflow](#example-workflow) is available below. For more information, reference the GitHub Help Documentation for [Creating a workflow file](https://help.github.com/en/articles/configuring-a-workflow#creating-a-workflow-file).
+Create a workflow `.yml` file in your repositories `.github/workflows` directory. An [example workflow](#example-workflows) is available below. For more information, reference the GitHub Help Documentation for [Creating a workflow file](https://help.github.com/en/articles/configuring-a-workflow#creating-a-workflow-file).
 
 ### Inputs
 
 * `ruby-version` - The version of Ruby you want to install
+* `cache-available` - A flag if a cached Ruby installation is available (see [the examples](#example-workflows) below)
 
 ### Outputs
 
 * `ruby-path` - The path to the Ruby exectuable that was installed
 
-### Example workflow
+### Example workflows
 
 ```yaml
 name: Example install of Ruby 2.6.5
@@ -31,13 +32,40 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-
-    - name: Install Ruby 2.6.5
+    - uses: clupprich/ruby-build-action@master
       id: ruby
-      uses: clupprich/ruby-build-action@master
       with:
         ruby-version: 2.6.5
-
     - name: Print version
       run: ${{ steps.ruby.outputs.ruby-path }} --version
 ```
+
+Note that installing Ruby from source is slow. However, you can cache the installation by using the [`actions/cache`](https://github.com/actions/cache) action, which is available as a preview right now:
+
+
+```yaml
+name: Example install of Ruby 2.6.5 (cached)
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/cache@preview
+      id: cache
+      with:
+        path: ~/local/rubies
+        key: ruby-2.6.5
+    - uses: clupprich/ruby-build-action@master
+      id: ruby
+      with:
+        ruby-version: 2.6.5
+        cache-available: ${{ steps.cache.outputs.cache-hit == 'true' }}
+    - name: Print version
+      run: ${{ steps.ruby.outputs.ruby-path }} --version
+```
+
+This runs way faster (we still need to install a couple of packages via `apt-get install`, though): The uncached version takes around 4 minutes to complete, the cached version 30 seconds.

--- a/action.yml
+++ b/action.yml
@@ -5,10 +5,14 @@ branding:
   color: red
   icon: code
 inputs:
-  ruby-version:  # id of input
+  ruby-version:
     description: 'Ruby version'
     required: true
     default: '2.6.5'
+  cache-available:
+    description: 'Flag if the Ruby installation is cached'
+    required: true
+    default: 'false'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -945,8 +945,16 @@ async function run() {
     core.endGroup()
 
     const rubyVersion = core.getInput('ruby-version');
+    const cacheAvailable = core.getInput('cache-available') == 'true'
+
     core.startGroup(`Installing ${rubyVersion}`)
-    await exec.exec(`ruby-build ${rubyVersion} ${process.env.HOME}/local/rubies/${rubyVersion}`)
+
+    if (!cacheAvailable) {
+      await exec.exec(`ruby-build ${rubyVersion} ${process.env.HOME}/local/rubies/${rubyVersion}`)
+    } else {
+      core.info(`Skipping installation of ${rubyVersion}, already available in cache.`)
+    }
+
     core.addPath(`${process.env.HOME}/local/rubies/${rubyVersion}/bin`)
     const rubyPath = await io.which('ruby', true)
     await exec.exec(`${rubyPath} --version`)

--- a/index.js
+++ b/index.js
@@ -12,8 +12,16 @@ async function run() {
     core.endGroup()
 
     const rubyVersion = core.getInput('ruby-version');
+    const cacheAvailable = core.getInput('cache-available') == 'true'
+
     core.startGroup(`Installing ${rubyVersion}`)
-    await exec.exec(`ruby-build ${rubyVersion} ${process.env.HOME}/local/rubies/${rubyVersion}`)
+
+    if (!cacheAvailable) {
+      await exec.exec(`ruby-build ${rubyVersion} ${process.env.HOME}/local/rubies/${rubyVersion}`)
+    } else {
+      core.info(`Skipping installation of ${rubyVersion}, already available in cache.`)
+    }
+
     core.addPath(`${process.env.HOME}/local/rubies/${rubyVersion}/bin`)
     const rubyPath = await io.which('ruby', true)
     await exec.exec(`${rubyPath} --version`)


### PR DESCRIPTION
Adds the `cache-available` input that will skip building the specified version of Ruby from source if it's already available in the cache.

See [actions/cache](https://github.com/actions/cache).